### PR TITLE
Skip appending a tag value if it's not in the given filter

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -34,6 +34,8 @@ def generate_id(instance, tags_filter, region):
     if tags_filter is not None:
         for tag in tags_filter.split(','):
             for aws_tag in instance['Instances'][0].get('Tags', []):
+                if aws_tag['Key'] != tag:
+                    continue
                 value = aws_tag['Value']
                 if value:
                     if not instance_id:


### PR DESCRIPTION
Fixes passing tag filter`--tags Name` from creating aliases appending all the tags on the instance instead of the user provided. 