### PR TITLE
Sort tags by key

### DIFF
--- a/aws-ssh-config.py
+++ b/aws-ssh-config.py
@@ -43,7 +43,7 @@ def generate_id(instance, tags_filter, region):
                     else:
                         instance_id += '-' + value
     else:
-        for tag in instance['Instances'][0].get('Tags', []):
+        for tag in sorted(instance['Instances'][0].get('Tags', []), key=lambda tag: tag['Key']):
             if not (tag['Key']).startswith('aws'):
                 if not instance_id:
                     instance_id = tag['Value']


### PR DESCRIPTION
Tag order is non-deterministic, so instances with the same tags set
might end up not getting sequential names, e.g. 'foo-bar' and
'bar-foo' instead of 'foo-bar-1' and 'foo-bar-2'.